### PR TITLE
Fixed issue where cloning impls required the sync struct to exist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncwrap"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["michael <mcarson898@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -21,4 +21,4 @@ sync = []
 [dependencies]
 syn = { version = "1", features = ["full"] }
 quote = "1"
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "1.3", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ automatically.
 # Usage
 ```toml
 [dependencies]
-syncwrap = "0.2.0"
+syncwrap = "0.4.0"
 ```
 
 Then in the crate that you want to have synchronous functions created for you

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! # Usage
 //! ```toml
 //! [dependencies]
-//! syncwrap = "0.2.0"
+//! syncwrap = "0.4.0"
 //! ```
 //!
 //! Then in the crate that you want to have synchronous functions created for you
@@ -268,6 +268,7 @@ pub fn clone_impl(_meta: TokenStream, input: TokenStream) -> TokenStream {
     }
 
     // Clone our async methods but wrap them
+    #[cfg(feature = "sync")]
     impl #sync_name {
       // wrap them to make the synchronous
       #(


### PR DESCRIPTION
This was caused by the fact that the functions inside the clone impl
were wrapped with syncwrap but the impl was not. This meant that
building would fail if the sync struct did not also exist.